### PR TITLE
Fix various reloading issues in debug and production modes

### DIFF
--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/factory/PropertiesBasedBundlesHandlerFactory.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/factory/PropertiesBasedBundlesHandlerFactory.java
@@ -301,7 +301,7 @@ public class PropertiesBasedBundlesHandlerFactory {
 			StringTokenizer tk = new StringTokenizer(childBundlesProperty, JawrConstant.COMMA_SEPARATOR);
 			while (tk.hasMoreTokens()) {
 				ResourceBundleDefinition childDef = buildCustomBundleDefinition(tk.nextToken().trim(), true);
-				childDef.setBundleId(bundleId);
+				childDef.setBundleId(props.getCustomBundleProperty(childDef.getBundleName(), BUNDLE_FACTORY_CUSTOM_ID));
 				if (StringUtils.isEmpty(childDef.getDebugURL())) {
 					children.add(childDef);
 				} else {

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/factory/PropsConfigPropertiesSource.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/factory/PropsConfigPropertiesSource.java
@@ -36,7 +36,7 @@ public class PropsConfigPropertiesSource implements ConfigPropertiesSource {
 	private final Properties configProps;
 
 	/** The properties hashcode */
-	protected int propsHashCode;
+	protected Integer propsHashCode;
 
 	/**
 	 * Constructor
@@ -57,7 +57,7 @@ public class PropsConfigPropertiesSource implements ConfigPropertiesSource {
 	@Override
 	public boolean configChanged() {
 		int currentConfigHash = this.configProps.hashCode();
-		boolean configChanged = this.propsHashCode != currentConfigHash;
+		boolean configChanged = propsHashCode!=null && this.propsHashCode != currentConfigHash;
 
 		if (configChanged && LOGGER.isDebugEnabled())
 			LOGGER.debug("Changes in configuration properties file detected.");

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/handler/reader/ServletContextResourceReaderHandler.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/handler/reader/ServletContextResourceReaderHandler.java
@@ -318,8 +318,8 @@ public class ServletContextResourceReaderHandler implements ResourceReaderHandle
 	 * 
 	 * @param rd
 	 *            the object
-	 * @param interfacesthe
-	 *            list of interfaces
+	 * @param interfaces
+	 *            the list of interfaces
 	 * @return true if the object is an instance of on interface from a list of
 	 *         interface
 	 */
@@ -486,6 +486,8 @@ public class ServletContextResourceReaderHandler implements ResourceReaderHandle
 					if (rsGeneratorBrowser.getResolver().matchPath(resourcePath)) {
 						filePath = rsBrowser.getFilePath(resourcePath);
 					}
+				} else {
+					filePath = rsBrowser.getFilePath(resourcePath);
 				}
 			} else {
 				if (!(rsBrowser instanceof ResourceGenerator)) {


### PR DESCRIPTION
Fix hotswapping of LESS files by ensuring the file path is returned from the ServletContextResourceReaderHandler. There was only one resourceInfoProvider which is a BaseServletContextResourceReader and it does not implement ResourceGenerator

Fix issues with child bundles being included instead of parent bundle because parent bundled was being used.
Ensure config change event doesn't occur on first check of configChanged.

Stop listeners and watchers and create anew after config change to ensure the bundlesHandler is consistent between the resource watcher and the rebuilding of dirty bundles in JawrRequestHandler